### PR TITLE
ci: QEMU 自动引导 + 一键复现;docs: 测试计数修正(148→实测)与 host 测试命令

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "Xtask dev (Rust + QEMU riscv32)",
+  "image": "mcr.microsoft.com/devcontainers/rust:1-bookworm",
+  "postCreateCommand": "rustup target add riscv32imac-unknown-none-elf && (command -v qemu-system-riscv32 >/dev/null 2>&1 || (sudo apt-get update && sudo apt-get install -y --no-install-recommends qemu-system-misc) || bash ci/get-qemu.sh)",
+  "customizations": {
+    "vscode": {
+      "extensions": ["rust-lang.rust-analyzer"]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 Cargo.lock
+
+# 自动引导的 QEMU(xPack 静态包)
+.tools/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ### 验证体系
 
-- [x] 宿主回归：`cargo test --lib` 默认 features 实测 **80 passed**;门禁全特征组合(见 `ci/gate.sh`,含 fs/net/usb/ble)实测 **157 passed**(2026-09-02,rustc 1.97;旧计数 148 已按实测修正,历史见 issue #11)
+- [x] 宿主回归：`cargo test --lib` 默认 features 实测 **80 passed**;门禁全特征组合(见 `ci/gate.sh`,含 fs/net/usb/ble)实测 **158 passed**(2026-09-03,rustc 1.97;旧计数 148 已按实测修正,历史见 issue #11;计数随新增测试浮动,以 `ci/gate.sh` 实测为准)
 - [x] QEMU 执行级：`ci/gate.sh` 在 virt 机真跑内核——`qemu_pingpong` 200 轮乒乓 + `qemu_kernel_tests` 24 项全内核机制自测(抢占/时间片/阻塞类 IPC/定时器/时基/堆/总线/任务回收/可重入锁/优先级继承/完整 PI 多锁/PCP 天花板阻塞/PI 交叉持锁死锁确认/TLSF 碎片共限/TLSF 分配确定性/tickless 错峰唤醒/远期期限单次到点/UART RX 外部中断冻眠唤醒/早醒弹墙钟拍账/噪声风暴停留 idle 不漂移),全绿自退出;另有 tlsf 全局后端门禁(24/24 不变 = 分配器换引擎对内核透明)与 `qemu_smp` 9 项多核调度门禁
 - [ ] 真机验证：gd32vf103 已验；f4/f1 常数、h7 时序、cm32m4、rp2040、ch32 系、esp32c3 待上板
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ### 验证体系
 
-- [x] 宿主回归：`cargo test --lib`(纯逻辑单测,无需硬件;当前 **148/148**,含第 28 章 TLSF 8 条与第 29 章 tickless 5 条:idle 三态决策 4 + 大跳账 1)
+- [x] 宿主回归：`cargo test --lib` 默认 features 实测 **80 passed**;门禁全特征组合(见 `ci/gate.sh`,含 fs/net/usb/ble)实测 **157 passed**(2026-09-02,rustc 1.97;旧计数 148 已按实测修正,历史见 issue #11)
 - [x] QEMU 执行级：`ci/gate.sh` 在 virt 机真跑内核——`qemu_pingpong` 200 轮乒乓 + `qemu_kernel_tests` 24 项全内核机制自测(抢占/时间片/阻塞类 IPC/定时器/时基/堆/总线/任务回收/可重入锁/优先级继承/完整 PI 多锁/PCP 天花板阻塞/PI 交叉持锁死锁确认/TLSF 碎片共限/TLSF 分配确定性/tickless 错峰唤醒/远期期限单次到点/UART RX 外部中断冻眠唤醒/早醒弹墙钟拍账/噪声风暴停留 idle 不漂移),全绿自退出;另有 tlsf 全局后端门禁(24/24 不变 = 分配器换引擎对内核透明)与 `qemu_smp` 9 项多核调度门禁
 - [ ] 真机验证：gd32vf103 已验；f4/f1 常数、h7 时序、cm32m4、rp2040、ch32 系、esp32c3 待上板
 
@@ -51,6 +51,21 @@
   - [x] RP2040(rp2040-hal 0.9;构建级验证 2026-08-23,真机待验)
 - CR5F
   - [x] qemu_arm_r52: QEMU xlnx-zcu102 的 Cortex-R5F(armv7r-none-eabi;**执行级验证** 2026-08-30——200 轮乒乓 + tick 心跳 + VFP 帧 100 轮跨切换保持,补丁版 QEMU 跑通;**CI 执行级门禁** `.github/workflows/r52.yml`——补丁版 QEMU 构建 + 双例程断言全绿;无 PendSV 架构的「中断借道 + 调度循环」移植,方法论见书稿第 31/32 章;真机待验)
+
+### 一键复现(读者零安装)
+
+- **通道 A · 本机一条命令**(首次自动下载静态 QEMU 到 `.tools/`,约 90MB):
+  ```bash
+  bash ci/gate.sh        # host 回归 + 示例链接 + QEMU 执行级(24/24 等)
+  ```
+- **通道 B · GitHub Codespaces**:仓库根有 `.devcontainer.json`,云端打开即跑,本机什么都不装
+- **通道 C · 只看结果**:每次 push 的 CI 门禁(含 QEMU 执行级)全绿记录:
+  [![main-gate](https://github.com/gqf2008/Xtask/actions/workflows/main-gate.yml/badge.svg)](https://github.com/gqf2008/Xtask/actions/workflows/main-gate.yml)
+- 只想跑 host 单测(不需要 QEMU):注意仓库 `.cargo/config.toml` 默认 `thumbv7em` target,
+  请显式指定宿主或先 `rustup target add thumbv7em-none-eabihf`:
+  ```bash
+  cargo test --lib --target "$(rustc -vV | sed -n 's/^host: //p')"
+  ```
 
 ### 快速开始
 

--- a/ci/gate.sh
+++ b/ci/gate.sh
@@ -8,6 +8,12 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 # 全脚本统一构建目录 = 主 target:与各步硬编码的 ELF 探测路径始终一致。
 export CARGO_TARGET_DIR="$ROOT_DIR/target"
 
+# --- 预检:riscv32imac target(读者环境通常未装)---
+if command -v rustup >/dev/null 2>&1     && ! rustup target list --installed | grep -q '^riscv32imac-unknown-none-elf$'; then
+    echo "== 安装缺失的 riscv32imac-unknown-none-elf target =="
+    rustup target add riscv32imac-unknown-none-elf
+fi
+
 echo "== [1/3] 内核 host 回归测试(阳性对照守卫)=="
 HOST_TRIPLE="$(rustc -vV | sed -n "s/^host: //p")"
 cargo test --manifest-path "$ROOT_DIR/Cargo.toml" --lib --target "$HOST_TRIPLE" \
@@ -40,6 +46,30 @@ echo "== [3/3] QEMU 执行门禁(virt 机跑真内核——调度/切换/节拍�
 QEMU_BIN="$(command -v qemu-system-riscv32 || true)"
 if [ -z "$QEMU_BIN" ] && [ -x "/c/Program Files/QEMU/qemu-system-riscv32.exe" ]; then
     QEMU_BIN="/c/Program Files/QEMU/qemu-system-riscv32.exe"
+fi
+# 仓库自带 xPack 静态版(.tools/,由 ci/get-qemu.sh 自动引导,读者零安装)
+if [ -z "$QEMU_BIN" ] && [ -x "$ROOT_DIR/.tools/qemu/bin/qemu-system-riscv32" ]; then
+    QEMU_BIN="$ROOT_DIR/.tools/qemu/bin/qemu-system-riscv32"
+fi
+if [ -z "$QEMU_BIN" ] && [ -x "$ROOT_DIR/.tools/qemu/bin/qemu-system-riscv32.exe" ]; then
+    QEMU_BIN="$ROOT_DIR/.tools/qemu/bin/qemu-system-riscv32.exe"
+fi
+# 都没有:自动下载(约 90MB,仅首次);失败给出读者通道提示
+if [ -z "$QEMU_BIN" ]; then
+    echo "== 未找到 qemu-system-riscv32,尝试自动引导(ci/get-qemu.sh) =="
+    if bash "$ROOT_DIR/ci/get-qemu.sh"; then
+        if [ -x "$ROOT_DIR/.tools/qemu/bin/qemu-system-riscv32.exe" ]; then
+            QEMU_BIN="$ROOT_DIR/.tools/qemu/bin/qemu-system-riscv32.exe"
+        else
+            QEMU_BIN="$ROOT_DIR/.tools/qemu/bin/qemu-system-riscv32"
+        fi
+    else
+        echo "自动引导失败。可选通道:" >&2
+        echo "  1. 手动安装 QEMU 后重跑" >&2
+        echo "  2. GitHub Codespaces(.devcontainer.json,打开即跑)" >&2
+        echo "  3. 直接查看 CI 门禁结果: https://github.com/gqf2008/Xtask/actions" >&2
+        exit 1
+    fi
 fi
 if [ -n "$QEMU_BIN" ]; then
     # qemu_pingpong:两任务 200 轮乒乓 + tick 心跳;跑满写 SiFive test 自退出

--- a/ci/get-qemu.sh
+++ b/ci/get-qemu.sh
@@ -25,6 +25,9 @@ esac
 EXT="tar.gz"; [ "$OS" = "win32" ] && EXT="zip"
 NAME="xpack-qemu-riscv-${VER}-${OS}-${ARCH}"
 EXE="qemu-system-riscv32"; [ "$OS" = "win32" ] && EXE="${EXE}.exe"
+# xPack 压缩包的解压根目录**不带平台后缀**(win32/linux/darwin 三平台实测一致):
+# 统一是 xpack-qemu-riscv-<ver>——曾误用带后缀的 $NAME 做 mv,导致引导全平台失败。
+SHORT="xpack-qemu-riscv-${VER}"
 
 DIR="$ROOT/.tools/qemu"
 if [ -x "$DIR/bin/$EXE" ]; then
@@ -39,9 +42,11 @@ mkdir -p "$ROOT/.tools" && cd "$ROOT/.tools"
 curl -fL --retry 3 -o "$NAME.$EXT" "$BASE_URL/$NAME.$EXT" \
   || { echo "下载失败: $BASE_URL/$NAME.$EXT"; exit 1; }
 
+# 清掉上次失败残留的解压根目录,避免 unzip 对已有文件交互式询问
+rm -rf "$ROOT/.tools/$SHORT"
 if [ "$EXT" = "zip" ]; then
   if command -v unzip >/dev/null 2>&1; then
-    unzip -q "$NAME.$EXT"
+    unzip -qo "$NAME.$EXT"
   elif command -v powershell >/dev/null 2>&1; then
     powershell -NoProfile -Command "Expand-Archive -Force '$NAME.$EXT' ."
   else
@@ -52,8 +57,8 @@ else
 fi
 rm -f "$NAME.$EXT"
 
-# 统一目录名(解压目录可能含版本号)
-if [ -d "$ROOT/.tools/$NAME" ]; then mv "$ROOT/.tools/$NAME" "$DIR"; fi
+# 统一目录名(解压根目录 = $SHORT,无平台后缀)
+if [ -d "$ROOT/.tools/$SHORT" ]; then mv "$ROOT/.tools/$SHORT" "$DIR"; fi
 [ -x "$DIR/bin/$EXE" ] || { echo "解压后未找到 $DIR/bin/$EXE"; ls "$ROOT/.tools"; exit 1; }
 echo "OK: $DIR/bin/$EXE"
 "$DIR/bin/$EXE" --version | head -1

--- a/ci/get-qemu.sh
+++ b/ci/get-qemu.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# 自动引导 QEMU(riscv32)静态二进制到 <repo>/.tools/qemu —— 读者零手工安装。
+# 用法: bash ci/get-qemu.sh
+# 来源: xPack qemu-riscv 静态发布(免管理员,免系统包管理器)
+# 可覆盖版本: QEMU_XPACK_VERSION=9.2.4-1 bash ci/get-qemu.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VER="${QEMU_XPACK_VERSION:-9.2.4-1}"
+BASE_URL="https://github.com/xpack-dev-tools/qemu-riscv-xpack/releases/download/v${VER}"
+
+# --- 平台探测 ---
+case "$(uname -s)" in
+  Linux)                         OS="linux"  ;;
+  Darwin)                        OS="darwin" ;;
+  MINGW*|MSYS*|CYGWIN*)          OS="win32"  ;;
+  *) echo "不支持的 OS: $(uname -s)"; exit 1 ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="x64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *) echo "不支持的架构: $(uname -m)"; exit 1 ;;
+esac
+# darwin-x64 在 Apple Silicon 上经 Rosetta 亦可;此处按真实内核取
+EXT="tar.gz"; [ "$OS" = "win32" ] && EXT="zip"
+NAME="xpack-qemu-riscv-${VER}-${OS}-${ARCH}"
+EXE="qemu-system-riscv32"; [ "$OS" = "win32" ] && EXE="${EXE}.exe"
+
+DIR="$ROOT/.tools/qemu"
+if [ -x "$DIR/bin/$EXE" ]; then
+  echo "QEMU 已就绪: $DIR/bin/$EXE"
+  "$DIR/bin/$EXE" --version | head -1
+  exit 0
+fi
+
+echo "== 未找到 qemu-system-riscv32,自动下载 xPack 静态包 =="
+echo "   $NAME.$EXT (~90MB, 首次仅一次)"
+mkdir -p "$ROOT/.tools" && cd "$ROOT/.tools"
+curl -fL --retry 3 -o "$NAME.$EXT" "$BASE_URL/$NAME.$EXT" \
+  || { echo "下载失败: $BASE_URL/$NAME.$EXT"; exit 1; }
+
+if [ "$EXT" = "zip" ]; then
+  if command -v unzip >/dev/null 2>&1; then
+    unzip -q "$NAME.$EXT"
+  elif command -v powershell >/dev/null 2>&1; then
+    powershell -NoProfile -Command "Expand-Archive -Force '$NAME.$EXT' ."
+  else
+    echo "需要 unzip 或 powershell 来解压"; exit 1
+  fi
+else
+  tar xzf "$NAME.$EXT"
+fi
+rm -f "$NAME.$EXT"
+
+# 统一目录名(解压目录可能含版本号)
+if [ -d "$ROOT/.tools/$NAME" ]; then mv "$ROOT/.tools/$NAME" "$DIR"; fi
+[ -x "$DIR/bin/$EXE" ] || { echo "解压后未找到 $DIR/bin/$EXE"; ls "$ROOT/.tools"; exit 1; }
+echo "OK: $DIR/bin/$EXE"
+"$DIR/bin/$EXE" --version | head -1
+echo "提示: ci/gate.sh 会自动使用 .tools/qemu/bin 下的 QEMU,无需手动加 PATH"

--- a/docs/设备驱动抽象层设计.md
+++ b/docs/设备驱动抽象层设计.md
@@ -1,8 +1,8 @@
 # 设备驱动抽象层重设计
 
-> 状态：已定稿
+> 状态：已定稿，已实施（b216a4d）
 > 归属：本文档由书稿侧起草、内核侧评审；代码实施在 Xtask 内核仓库，书稿修订在 xtask-book 私有仓库。
-> 关联模块：`src/drv.rs`、`src/drv_static.rs`、`src/bsp/longan_nano/drv_{led,uart,sd}.rs`
+> 关联模块：`src/device.rs`、`src/device/table.rs`、`src/bsp/longan_nano/drv_{led,uart,sd}.rs`（旧 `src/drv.rs` / `src/drv_static.rs` 已合并入 `device` 模块并删除）
 > 关联书稿：第 20 章《驱动抽象层》
 
 ## 1. 背景与问题

--- a/docs/设备驱动抽象层设计.md
+++ b/docs/设备驱动抽象层设计.md
@@ -1,6 +1,6 @@
 # 设备驱动抽象层重设计
 
-> 状态：已定稿，已实施（b216a4d）
+> 状态：已定稿，已实施（内核侧 `feat(device)` 提交，驱动抽象层重构）
 > 归属：本文档由书稿侧起草、内核侧评审；代码实施在 Xtask 内核仓库，书稿修订在 xtask-book 私有仓库。
 > 关联模块：`src/device.rs`、`src/device/table.rs`、`src/bsp/longan_nano/drv_{led,uart,sd}.rs`（旧 `src/drv.rs` / `src/drv_static.rs` 已合并入 `device` 模块并删除）
 > 关联书稿：第 20 章《驱动抽象层》

--- a/examples/ble_gatt.rs
+++ b/examples/ble_gatt.rs
@@ -32,8 +32,9 @@ use xtask::prelude::*;
 // 任务:ble-pump(prio 2)五阶段——握手(容错)→ 配置 7 步 → 等
 // STA:wakeup → 开广播+打印 GATT 树 → 稳态(事件日志/FFF2 回显/心跳);
 // led-blink(prio 1)绿 500ms。日志走 RTT。
-// ⚠️ 红线:握手/配置全部在任务里(xtask::start() 之前 read_byte 会踩
-// xworker.current() 空指针——书稿踩坑 5)。
+// ⚠️ 红线:握手/配置全部在任务里(start() 之前中断未开、无数据可达,
+// send 只会把字节预算耗成超时;阻塞读的 xworker 空指针踩坑面已随驱动层
+// 重构移入 device::read_blocking——书稿踩坑 5)。
 
 /// 自定义 GATT 树:服务 0x1102,板→手机 0x1103,手机→板 0x1104
 const SVR: u16 = 0x1102;

--- a/src/ble/at.rs
+++ b/src/ble/at.rs
@@ -382,10 +382,13 @@ pub enum AtError {
 
 /// AT 会话:一条 UART 上的命令/应答状态机。
 ///
-/// ⚠️ **红线(书稿踩坑):`send` 只能在任务上下文调用**——空缓冲的
-/// `read_byte` 会经任务状态机挂起,在 `xtask::start()` 之前的 init/main
-/// 里调用将命中 `xworker.current()` 的空指针解引用。boot 上下文只用
-/// `poll()`(非阻塞,`rx_len>0` 才读)。
+/// ⚠️ **红线变迁(书稿踩坑 5):旧版 `read_byte` 是阻塞读**,空缓冲会经任务
+/// 状态机挂起,在 `xtask::start()` 之前调用命中 `xworker.current()` 的空指针
+/// 解引用——该踩坑面已随驱动层重构移入内核适配器 `device::read_blocking`
+/// (它仍是"仅任务上下文",见其上调用契约)。本层的 `read_byte` 现为
+/// **非阻塞读**(`rx_len>0` 才调),`send` 空缓冲只走 `yield_now` + 字节
+/// 预算——机制上任何上下文安全;但 boot 上下文里中断未开、永远等不到
+/// 字节,只会把预算耗成 `Timeout`。纪律不变:boot 上下文只用 `poll()`。
 pub struct AtSession<'a> {
     io: &'a dyn BleIo,
     dec: RespDecoder,
@@ -416,7 +419,8 @@ impl<'a> AtSession<'a> {
         None
     }
 
-    /// 发送并阻塞收集第一条应答行(**仅任务上下文**——见类型文档红线)。
+    /// 发送并收集第一条应答行(空缓冲走 `yield_now` + 字节预算,机制上
+    /// 任何上下文安全;boot 下只会耗成 `Timeout`——见类型文档红线变迁)。
     /// 先 `poll` 清场(丢弃上一命令的迟到残行);`RX_BUDGET` 字节内
     /// 无完整行 → `Err(Timeout)`。模块回 `+ERR=N` 仍是 `Ok`——
     /// 传输成功与模块错误分层。

--- a/src/device.rs
+++ b/src/device.rs
@@ -193,8 +193,9 @@ pub trait BlockDevice: Device {
 ///   （可加方向/尺寸位），让"指针还是标量"在命令码上可判读。
 ///
 /// 返回值：查询型 op 返回设备写回的字节数/数值；设置型返回 `Ok(0)`；
-/// 未知 op 返回 `Err(InvalidInput)`；设备不支持控制面则不实现本 trait
-/// （`as_control` 默认 None）。
+/// 未知 op 返回 `Err(InvalidInput)`；**占位实现**（能力已暴露、命令面
+/// 尚未定义，如 Uart0）可对一切 op 报 `Err(Unsupported)`；设备不支持
+/// 控制面则不实现本 trait（`as_control` 默认 None）。
 pub trait Control: Device {
     /// 执行控制指令；`op`/`arg` 语义由设备族自定（见 trait 级约定）
     fn control(&self, op: u32, arg: usize) -> Result<usize, DeviceError>;
@@ -241,6 +242,12 @@ pub trait EventDevice: Device {
 /// 丢失唤醒免疫（沿用 `drv_uart` 的踩坑纪律）：**"复查 available + 登记
 /// waiter + 挂起"在同一 `sync::free` 临界区内**——ISR 不可能插进"发现空"
 /// 与"挂起"之间；先入队的字节必然看到 waiter 已登记。
+///
+/// **调用契约**（沿用旧 `read_byte` 的红线）：
+/// - **仅任务上下文**（调度器启动后）：内部走 `xworker.current()` +
+///   `Task::block()`，boot 上下文/ISR 里调用即踩空指针/破坏任务状态机；
+/// - **单读者**：同一设备同一时刻只允许一个任务调用——`EventDevice` 是
+///   单等待者语义，并发调用互相覆盖 waiter，先登记者永久丢失唤醒。
 pub fn read_blocking(dev: &dyn Device, buf: &mut [u8]) -> Result<usize, DeviceError> {
     let stream = dev.as_stream().ok_or(DeviceError::Unsupported)?;
     let event = dev.as_event().ok_or(DeviceError::Unsupported)?;

--- a/src/device/table.rs
+++ b/src/device/table.rs
@@ -215,7 +215,7 @@ pub fn find_event(name: &str) -> Option<&'static dyn EventDevice> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::device::{DeviceError, DeviceKind};
+    use crate::device::{DeviceError, DeviceKind, SECTOR_SIZE};
     use alloc::boxed::Box;
     use alloc::sync::Arc;
     use core::sync::atomic::{AtomicUsize, Ordering};
@@ -282,6 +282,53 @@ mod tests {
             Ok(())
         }
         fn wake(&self) {}
+    }
+
+    /// mock 块设备：容量 4 扇区，读计数透传
+    struct MockBlock {
+        reads: Arc<AtomicUsize>,
+    }
+    impl Device for MockBlock {
+        fn kind(&self) -> DeviceKind {
+            DeviceKind::Block
+        }
+        fn as_block(&self) -> Option<&dyn BlockDevice> {
+            Some(self)
+        }
+    }
+    impl BlockDevice for MockBlock {
+        fn sector_size(&self) -> u64 {
+            SECTOR_SIZE
+        }
+        fn sector_count(&self) -> u64 {
+            4
+        }
+        fn read_sector(&self, _no: u64, _buf: &mut [u8]) -> Result<(), DeviceError> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        fn write_sector(&self, _no: u64, _buf: &[u8]) -> Result<(), DeviceError> {
+            Ok(())
+        }
+    }
+
+    /// mock 总线设备：transfer 累计 tx 字节数
+    struct MockBus {
+        xfer: Arc<AtomicUsize>,
+    }
+    impl Device for MockBus {
+        fn kind(&self) -> DeviceKind {
+            DeviceKind::Bus
+        }
+        fn as_bus(&self) -> Option<&dyn BusDevice> {
+            Some(self)
+        }
+    }
+    impl BusDevice for MockBus {
+        fn transfer(&self, tx: &[u8], _rx: &mut [u8]) -> Result<(), DeviceError> {
+            self.xfer.fetch_add(tx.len(), Ordering::SeqCst);
+            Ok(())
+        }
     }
 
     fn mock_led() -> (&'static dyn Device, Arc<AtomicUsize>) {
@@ -367,6 +414,43 @@ mod tests {
             .register_waiter(0x55)
             .unwrap();
         assert_eq!(registered.load(Ordering::SeqCst), 0x55);
+    }
+
+    /// 回归：清单侧 `find_block` / `find_bus` 全路径。五条便捷查找同为
+    /// find+as_* 薄包装，但按设计稿 §10 纪律——每能力的 host 单测必须覆盖
+    /// register/fill→find_xxx→透传 全路径，防 `as_*` 漏 override 静默 None——
+    /// 清单侧也要 5/5（本测试补块与总线两条）。
+    #[test]
+    fn find_block_and_bus_roundtrip() {
+        static SD_SLOT: DeviceSlot = DeviceSlot::new();
+        static SPI_SLOT: DeviceSlot = DeviceSlot::new();
+        const LIST: &[DeviceDef] = &[
+            DeviceDef::new("sd0", &SD_SLOT),
+            DeviceDef::new("spi1", &SPI_SLOT),
+        ];
+        let table = DeviceTable::new();
+        table.attach(LIST);
+
+        let reads = Arc::new(AtomicUsize::new(0));
+        let sd: &'static dyn Device = Box::leak(Box::new(MockBlock {
+            reads: reads.clone(),
+        }));
+        SD_SLOT.fill(sd);
+        let b = table.find_block("sd0").expect("填槽后应能找到块能力");
+        assert_eq!(b.sector_size(), SECTOR_SIZE);
+        assert_eq!(b.sector_count(), 4);
+        let mut buf = [0u8; SECTOR_SIZE as usize];
+        b.read_sector(0, &mut buf).unwrap();
+        assert_eq!(reads.load(Ordering::SeqCst), 1, "读计数应透传到同一实例");
+        assert!(table.find_bus("sd0").is_none(), "块设备按总线找应 None");
+
+        let xfer = Arc::new(AtomicUsize::new(0));
+        let spi: &'static dyn Device = Box::leak(Box::new(MockBus { xfer: xfer.clone() }));
+        SPI_SLOT.fill(spi);
+        let bus = table.find_bus("spi1").expect("填槽后应能找到总线能力");
+        bus.transfer(&[1, 2], &mut []).unwrap();
+        assert_eq!(xfer.load(Ordering::SeqCst), 2, "tx 字节数应透传到同一实例");
+        assert!(table.find_block("spi1").is_none(), "总线设备按块找应 None");
     }
 
     /// 回归：名字不在清单 → None；能力不符 → find_control/find_stream 各得 None。


### PR DESCRIPTION
## 动机
- #12: README 的 `cargo test --lib` 在干净机器直接 E0463(`.cargo/config.toml` 默认 thumbv7em)
- 读者不会手动装 QEMU → 执行级验证需要**零安装**通道
- #11: 宿主回归计数 148 与实测不符

## 实测结论(issue #11 的答案)
- `cargo test --lib`(默认 features): **80 passed**
- 门禁同款特征组合(`--no-default-features --features xtask_executor,xtask_scheduler,timer,fs,net,usb,ble`,即 `ci/gate.sh` 第 1 步): **157 passed**(= 源码中 157 处 `#[test]`)
- 结论:README 的 148 为**过时计数**,已在本 PR 修正为实测值

## 改动
| 文件 | 内容 |
|---|---|
| `ci/get-qemu.sh`(新) | 自动下载 xPack 静态 QEMU riscv 到 `.tools/`(免管理员;Windows/macOS/Linux) |
| `ci/gate.sh` | QEMU 缺失→自动引导;riscv32imac target 缺失→rustup 自动补装;失败给读者通道提示 |
| `.devcontainer.json`(新) | Codespaces 打开即跑(自动补 target + QEMU) |
| `README.md` | 新增「一键复现(读者零安装)」三通道(A 本机一条命令/B Codespaces/C CI 徽章);计数修正;host 命令显式 `--target` |
| `.gitignore` | 忽略 `.tools/` |

Closes #12, refs #11